### PR TITLE
Unlocking Addition and Subtraction beyond 100

### DIFF
--- a/src/routes/add/addQuestions.js
+++ b/src/routes/add/addQuestions.js
@@ -42,11 +42,11 @@ const initialState = {
   25: { unlocks: 50 },
   50: { unlocks: 75 },
   75: { unlocks: 100 },
-  100: { unlocks: 100 },
-  200: { unlocks: 200 },
-  250: { unlocks: 250 },
-  500: { unlocks: 500 },
-  750: { unlocks: 750 },
+  100: { unlocks: 200 },
+  200: { unlocks: 250 },
+  250: { unlocks: 500 },
+  500: { unlocks: 750 },
+  750: { unlocks: 999 },
   999: { unlocks: null },
 }
 

--- a/src/routes/subtract/subtractQuestions.js
+++ b/src/routes/subtract/subtractQuestions.js
@@ -43,11 +43,11 @@ const initialState = {
   25: { unlocks: 50 },
   50: { unlocks: 75 },
   75: { unlocks: 100 },
-  100: { unlocks: 100 },
-  200: { unlocks: 200 },
-  250: { unlocks: 250 },
-  500: { unlocks: 500 },
-  750: { unlocks: 750 },
+  100: { unlocks: 200 },
+  200: { unlocks: 250 },
+  250: { unlocks: 500 },
+  500: { unlocks: 750 },
+  750: { unlocks: 999 },
   999: { unlocks: null },
 }
 


### PR DESCRIPTION
In `https://tafels.app/` you can not unlock Addition and Subtraction challenges beyond 100. 